### PR TITLE
run_model um container methode erweitert

### DIFF
--- a/ogs6py/ogs.py
+++ b/ogs6py/ogs.py
@@ -447,7 +447,7 @@ class OGS:
             Default: out
         path : `str`, optional
             Path of the directory in which the ogs executable can be found.
-            If ``container_path`` is given: Path to the directory in which the 
+            If ``container_path`` is given: Path to the directory in which the
             Singularity executable can be found
         container_path : `str`, optional
             Path of the OGS container file.
@@ -477,7 +477,7 @@ class OGS:
                     raise RuntimeError('The specified path is not a directory. Please provide a directory containing the Singularity executable.')
                 else:
                     raise RuntimeError('The specified path is not a directory. Please provide a directory containing the OGS executable.')
-            ogs_path += args["path"]     
+            ogs_path += args["path"]
         if "logfile" in args:
             self.logfile = args["logfile"]
         else:

--- a/tests/test_ogs6py_model_run.py
+++ b/tests/test_ogs6py_model_run.py
@@ -14,7 +14,7 @@ class TestiOGSModelrun(unittest.TestCase):
         x_file = tempfile.NamedTemporaryFile(suffix=".x")
         # dummy directory
         sing_dir = tempfile.TemporaryDirectory()
-        
+
         # case: path is not a dir
         model = ogs6py.OGS(INPUT_FILE=prjfile, PROJECT_FILE=prjfile)
         with self.assertRaises(RuntimeError) as cm:
@@ -42,9 +42,9 @@ class TestiOGSModelrun(unittest.TestCase):
             model.run_model(path=sing_dir.name, container_path=sif_file.name)
         self.assertEqual('The Singularity executable was not found. See https://www.opengeosys.org/docs/userguide/basics/container/ for installation instructions.',
             str(cm.exception))
-        
+
         # clean up the temporary dir
         sing_dir.cleanup()
-        
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Hallo Jörg,

wie gestern gesprochen hier mein Code um mit der model_run methode container auszuführen. Ich hab auch einen Test geschrieben und soweit alles ausprobiert. Für jegliches Feedback bin ich dankbar - habe vorher noch nie an einem großen Projekt gearbeitet.

PS: In älteren Containern muss singularity mit dem Befehl singularity exec --app ogs [..] ausgeführt werden (anstatt singularity exec [..]). Ob dies in einen try/except Block eingebaut werden soll, oder ob der Nutzer am Ende nur die neusten Container (6.4.x aufwärts) benutzen kann - ich war mir nicht sicher.

Beste Grüße
Oliver