### PR TITLE
Pass cmd as string to subprocess.run()

### DIFF
--- a/ogs6py/ogs.py
+++ b/ogs6py/ogs.py
@@ -493,9 +493,9 @@ class OGS:
             cmd += f"{self.prjfile}"
         startt = time.time()
         if sys.platform == "win32":
-            returncode = subprocess.run([cmd], shell=True, stdout=subprocess.DEVNULL, stderr=subprocess.STDOUT)
+            returncode = subprocess.run(cmd, shell=True, stdout=subprocess.DEVNULL, stderr=subprocess.STDOUT)
         else:
-            returncode = subprocess.run([cmd], shell=True, executable="/bin/bash", stdout=subprocess.DEVNULL, stderr=subprocess.STDOUT)
+            returncode = subprocess.run(cmd, shell=True, executable="/bin/bash", stdout=subprocess.DEVNULL, stderr=subprocess.STDOUT)
         stopt = time.time()
         self.exec_time = stopt - startt
         if returncode.returncode == 0:


### PR DESCRIPTION
See
https://docs.python.org/3/library/subprocess.html#subprocess.CompletedProcess.args:

> This may be a list or a string.

The command is constructed as a string and should be passed as a string.

This fixes `run_model()` on Windows.