### PR TITLE
Adding wrapper command to singularity execution

### DIFF
--- a/ogs6py/ogs.py
+++ b/ogs6py/ogs.py
@@ -496,7 +496,10 @@ class OGS:
             cmd += wrapper + " "
         cmd += f"{ogs_path} "
         if not container_path is None:
-            cmd += "exec " + f"{container_path} " + "ogs "
+            if not wrapper is None:
+                cmd = env_export + "singularity exec " + f"{container_path} " + wrapper + " "
+            else:
+                cmd = env_export + "singularity exec " + f"{container_path} " + "ogs "
         if not args is None:
             cmd += f"{args} "
         if write_logs is True:


### PR DESCRIPTION
Hi,

When execution OGS from a container, the wrapper function could not be used. I modified the specific part in run_model to now execute the wrapper via container if given.

Kind regards
Oliver Petschick