### PR TITLE
Fix for component error in Newton evaluation

### DIFF
--- a/ogs6py/log_parser/common_ogs_analyses.py
+++ b/ogs6py/log_parser/common_ogs_analyses.py
@@ -92,7 +92,9 @@ def analysis_convergence_newton_iteration(df):
         pt = dfe_newton_iteration.pivot_table(interest, context)
 
     else:
-        context = ['time_step', 'process', 'iteration_number', 'component']
+        context = ['time_step', 'process', 'iteration_number']
+        if 'component' in df.columns:
+            context.append('component')
         check_input(df, interest, context)
         pt = dfe_newton_iteration.pivot_table(interest, context)
 


### PR DESCRIPTION
'Component' in context causes error for single processes. This MR fixes that. 