### PR TITLE
Remove /bin/bash in subprocess.run()

### DIFF
--- a/ogs6py/ogs.py
+++ b/ogs6py/ogs.py
@@ -683,10 +683,7 @@ class OGS:
         else:
             cmd += f"{self.prjfile}"
         startt = time.time()
-        if sys.platform == "win32":
-            returncode = subprocess.run(cmd, shell=True, stdout=subprocess.DEVNULL, stderr=subprocess.STDOUT)
-        else:
-            returncode = subprocess.run(cmd, shell=True, executable="/bin/bash", stdout=subprocess.DEVNULL, stderr=subprocess.STDOUT)
+        returncode = subprocess.run(cmd, shell=True, stdout=subprocess.DEVNULL, stderr=subprocess.STDOUT)
         stopt = time.time()
         self.exec_time = stopt - startt
         if returncode.returncode == 0:


### PR DESCRIPTION
There are systems where `/bin/bash` is not available at all or installed in another location. In my opinion there is no reason to specify `executable` here.